### PR TITLE
fix: bump base image from 8.5-243 to 8.6-902

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8-minimal:8.5-243
+FROM registry.access.redhat.com/ubi8-minimal:8.6-902
 
 LABEL org.opencontainers.image.authors="Adfinis AG <https://adfinis.com>"
 LABEL org.opencontainers.image.vendor="Adfinis"


### PR DESCRIPTION
Looks like dependabot dropped the ball on this again. I'm updating it now before the underlying security issues i suspect being in -902 are past embargo.