### PR TITLE
fix: update base ubi8 image from 8.6-902 to 8.6-902.1661794353

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8-minimal:8.6-902
+FROM registry.access.redhat.com/ubi8-minimal:8.6-902.1661794353
 
 LABEL org.opencontainers.image.authors="Adfinis AG <https://adfinis.com>"
 LABEL org.opencontainers.image.vendor="Adfinis"


### PR DESCRIPTION
Updates tzdata, curl, libcurl, and systemd-libs.

* [CVE-2022-32206](https://access.redhat.com/security/cve/CVE-2022-32206)
* [CVE-2022-2526](https://access.redhat.com/security/cve/CVE-2022-2526)

The linked CVEs are about fixing the recent use-after-free in systemd. The curl patches are apotential  malloc bomb that probably doesn't affect this image. The use-after-free in systemd has been classfied as important by Red Hat scoring a 8.8 on the CVSS v3 scale.