### PR TITLE
feat(dockerfile): use ubi9-minimal as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8-minimal:8.9-1029
+FROM registry.access.redhat.com/ubi9-minimal:9.3-1361.1699548032
 
 LABEL org.opencontainers.image.authors="Adfinis AG <https://adfinis.com>"
 LABEL org.opencontainers.image.vendor="Adfinis"


### PR DESCRIPTION
Starting with OpenShift 4.13 the RHCOS image used for nodes will be based on RHEL 9.2, so we're going to use ubi9-minimal going forward. https://access.redhat.com/articles/6907891

fixes #67