### PR TITLE
fix(backup.sh): disable S3 by default

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -31,6 +31,8 @@
 
 set -xeuo pipefail
 
+OCP_BACKUP_S3="false"
+
 # check storage type
 if [ "${OCP_BACKUP_S3}" = "true" ]; then
     # prepare & push backup to S3

--- a/backup.sh
+++ b/backup.sh
@@ -31,7 +31,7 @@
 
 set -xeuo pipefail
 
-OCP_BACKUP_S3="false"
+OCP_BACKUP_S3=""
 
 # check storage type
 if [ "${OCP_BACKUP_S3}" = "true" ]; then


### PR DESCRIPTION
Because we are using `set -u` and the variable is not set in case of not using S3 we have to disable by design. Other solution would be to remove `set -u` but we do not want that.