### PR TITLE
ci(release): replace shell script with docker/metadata-action

### DIFF
--- a/.github/workflows/release-container-image.yaml
+++ b/.github/workflows/release-container-image.yaml
@@ -22,42 +22,21 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Prepare Image Metadata
-        id: prep
-        run: |
-          DOCKER_IMAGE=docker.io/adfinissygroup/openshift-etcd-backup
-          GHCR_IMAGE=ghcr.io/adfinis/openshift-etcd-backup
-          QUAY_IMAGE=quay.io/adfinis/openshift-etcd-backup
-          VERSION=noop
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            VERSION=nightly
-          elif [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
-          elif [[ $GITHUB_REF == refs/heads/* ]]; then
-            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
-            if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
-              VERSION=edge
-            fi
-          elif [[ $GITHUB_REF == refs/pull/* ]]; then
-            VERSION=pr-${{ github.event.number }}
-          fi
-          TAGS="${DOCKER_IMAGE}:${VERSION}"
-          TAGS="$TAGS,${GHCR_IMAGE}:${VERSION}"
-          TAGS="$TAGS,${QUAY_IMAGE}:${VERSION}"
-          if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-            MINOR=${VERSION%.*}
-            MAJOR=${MINOR%.*}
-            TAGS="$TAGS,${DOCKER_IMAGE}:${MINOR},${DOCKER_IMAGE}:${MAJOR},${DOCKER_IMAGE}:latest"
-            TAGS="$TAGS,${GHCR_IMAGE}:${MINOR},${GHCR_IMAGE}:${MAJOR},${GHCR_IMAGE}:latest"
-            TAGS="$TAGS,${QUAY_IMAGE}:${MINOR},${QUAY_IMAGE}:${MAJOR},${QUAY_IMAGE}:latest"
-          elif [ "${{ github.event_name }}" = "push" ]; then
-            TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
-            TAGS="$TAGS,${GHCR_IMAGE}:sha-${GITHUB_SHA::8}"
-            TAGS="$TAGS,${QUAY_IMAGE}:sha-${GITHUB_SHA::8}"
-          fi
-          echo ::set-output name=version::${VERSION}
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+      - name: Configure Image Metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            docker.io/adfinissygroup/openshift-etcd-backup
+            ghcr.io/adfinis/openshift-etcd-backup
+            quay.io/adfinis/openshift-etcd-backup
+          tags: |
+            type=schedule,pattern=nightly
+            type=edge
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=ref,event=pr
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -89,13 +68,5 @@ jobs:
           context: .
           file: ./Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.prep.outputs.tags }}
-          labels: |
-            org.opencontainers.image.title=${{ github.event.repository.name }}
-            org.opencontainers.image.description=${{ github.event.repository.description }}
-            org.opencontainers.image.url=${{ github.event.repository.html_url }}
-            org.opencontainers.image.source=${{ github.event.repository.clone_url }}
-            org.opencontainers.image.version=${{ steps.prep.outputs.version }}
-            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
After a discussion with @hairmare last week I did look into the required changes.

I believe I've caught all existing tags, but be aware that I've decided to drop the `sha-...` tags, as we're not actually using them anywhere.