### PR TITLE
feat(backup.sh): add separate s3 bucket functionality for kuberesources

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -33,75 +33,92 @@ set -xeuo pipefail
 
 # check storage type
 if [ "${OCP_BACKUP_S3}" = "true" ]; then
-    # prepare & push backup to S3
+	# prepare & push backup to S3
 
-    # update CA trust
-    update-ca-trust
+	# update CA trust
+	update-ca-trust
 
-    # configure mcli assuming the bucket already exists
-    bash +o history
-    mcli alias set "${OCP_BACKUP_S3_NAME}" "${OCP_BACKUP_S3_HOST}" "${OCP_BACKUP_S3_ACCESS_KEY}" "${OCP_BACKUP_S3_SECRET_KEY}"
-    bash -o history
+	# configure mcli assuming the bucket already exists
+	bash +o history
+	mcli alias set "${OCP_BACKUP_S3_NAME}" "${OCP_BACKUP_S3_HOST}" "${OCP_BACKUP_S3_ACCESS_KEY}" "${OCP_BACKUP_S3_SECRET_KEY}"
+	if [[ -n ${OCP_BACKUP_KUBERESOURCES_S3_NAME} ]]; then
+		mcli alias set "${OCP_BACKUP_KUBERESOURCES_S3_NAME}" "${OCP_BACKUP_KUBERESOURCES_S3_HOST}" "${OCP_BACKUP_KUBERESOURCES_S3_ACCESS_KEY}" "${OCP_BACKUP_KUBERESOURCES_S3_SECRET_KEY}"
+	fi
+	bash -o history
 
-    # make dirname
-    BACKUP_FOLDER="$( date "${OCP_BACKUP_DIRNAME}")" || { echo "Invalid backup.dirname" && exit 1; }
+	# make dirname
+	BACKUP_FOLDER="$(date "${OCP_BACKUP_DIRNAME}")" || { echo "Invalid backup.dirname" && exit 1; }
 
-    # make necessary directory
-    mkdir -p "/host/var/tmp/etcd-backup/${BACKUP_FOLDER}"
+	# make necessary directory
+	mkdir -p "/host/var/tmp/etcd-backup/${BACKUP_FOLDER}"
 
-    # create backup to temporary location
-    chroot /host /usr/local/bin/cluster-backup.sh "/var/tmp/etcd-backup/${BACKUP_FOLDER}"
+	# create backup to temporary location
+	chroot /host /usr/local/bin/cluster-backup.sh "/var/tmp/etcd-backup/${BACKUP_FOLDER}"
 
-    # move files to S3 and delete temporary files
-    mcli mv -r /host/var/tmp/etcd-backup/* "${OCP_BACKUP_S3_NAME}"/"${OCP_BACKUP_S3_BUCKET}"
-    rm -rv /host/var/tmp/etcd-backup
+	if [[ -n ${OCP_BACKUP_KUBERESOURCES_S3_NAME} ]]; then
+		# move asset file to separate s3 bucket and delete them
+		mcli mv -r /host/var/tmp/etcd-backup/static_kuberesources*tar.gz "${OCP_BACKUP_S3_KUBEREOSURCES_NAME}"/"${OCP_BACKUP_KUBERESOURCES_S3_BUCKET}"
+		rm -rv /host/var/tmp/etcd-backup/static_kuberesources*tar.gz
+	fi
+	# move files to S3 and delete temporary files
+	mcli mv -r /host/var/tmp/etcd-backup/* "${OCP_BACKUP_S3_NAME}"/"${OCP_BACKUP_S3_BUCKET}"
+	rm -rv /host/var/tmp/etcd-backup
 else
-    # prepare, run and copy backup
+	# prepare, run and copy backup
 
-    # set proper umask
-    umask "${OCP_BACKUP_UMASK}"
+	# set proper umask
+	umask "${OCP_BACKUP_UMASK}"
 
-    # validate expire type
-    case "${OCP_BACKUP_EXPIRE_TYPE}" in
-        days|count|never) ;;
-        *) echo "backup.expiretype needs to be one of: days,count,never"; exit 1 ;;
-    esac
+	# validate expire type
+	case "${OCP_BACKUP_EXPIRE_TYPE}" in
+	days | count | never) ;;
+	*)
+		echo "backup.expiretype needs to be one of: days,count,never"
+		exit 1
+		;;
+	esac
 
-    # validate expire numbers
-    if [ "${OCP_BACKUP_EXPIRE_TYPE}" = "days" ]; then
-      case "${OCP_BACKUP_KEEP_DAYS}" in
-        ''|*[!0-9]*) echo "backup.expiredays needs to be a valid number"; exit 1 ;;
-        *) ;;
-      esac
-    elif [ "${OCP_BACKUP_EXPIRE_TYPE}" = "count" ]; then
-      case "${OCP_BACKUP_KEEP_COUNT}" in
-        ''|*[!0-9]*) echo "backup.expirecount needs to be a valid number"; exit 1 ;;
-        *) ;;
-      esac
-    fi
+	# validate expire numbers
+	if [ "${OCP_BACKUP_EXPIRE_TYPE}" = "days" ]; then
+		case "${OCP_BACKUP_KEEP_DAYS}" in
+		'' | *[!0-9]*)
+			echo "backup.expiredays needs to be a valid number"
+			exit 1
+			;;
+		*) ;;
+		esac
+	elif [ "${OCP_BACKUP_EXPIRE_TYPE}" = "count" ]; then
+		case "${OCP_BACKUP_KEEP_COUNT}" in
+		'' | *[!0-9]*)
+			echo "backup.expirecount needs to be a valid number"
+			exit 1
+			;;
+		*) ;;
+		esac
+	fi
 
-    # make dirname and cleanup paths
-    BACKUP_FOLDER="$( date "${OCP_BACKUP_DIRNAME}")" || { echo "Invalid backup.dirname" && exit 1; }
-    BACKUP_PATH="$( realpath -m "${OCP_BACKUP_SUBDIR}/${BACKUP_FOLDER}" )"
-    BACKUP_PATH_POD="$( realpath -m "/backup/${BACKUP_PATH}" )"
-    BACKUP_ROOTPATH="$( realpath -m "/backup/${OCP_BACKUP_SUBDIR}" )"
+	# make dirname and cleanup paths
+	BACKUP_FOLDER="$(date "${OCP_BACKUP_DIRNAME}")" || { echo "Invalid backup.dirname" && exit 1; }
+	BACKUP_PATH="$(realpath -m "${OCP_BACKUP_SUBDIR}/${BACKUP_FOLDER}")"
+	BACKUP_PATH_POD="$(realpath -m "/backup/${BACKUP_PATH}")"
+	BACKUP_ROOTPATH="$(realpath -m "/backup/${OCP_BACKUP_SUBDIR}")"
 
-    # make necessary directories
-    mkdir -p "/host/var/tmp/etcd-backup"
-    mkdir -p "${BACKUP_PATH_POD}"
+	# make necessary directories
+	mkdir -p "/host/var/tmp/etcd-backup"
+	mkdir -p "${BACKUP_PATH_POD}"
 
-    # create backup to temporary location
-    chroot /host /usr/local/bin/cluster-backup.sh /var/tmp/etcd-backup
+	# create backup to temporary location
+	chroot /host /usr/local/bin/cluster-backup.sh /var/tmp/etcd-backup
 
-    # move files to PVC and delete temporary files
-    mv /host/var/tmp/etcd-backup/* "${BACKUP_PATH_POD}"
-    rm -rv /host/var/tmp/etcd-backup
+	# move files to PVC and delete temporary files
+	mv /host/var/tmp/etcd-backup/* "${BACKUP_PATH_POD}"
+	rm -rv /host/var/tmp/etcd-backup
 
-    # expire backup
-    if [ "${OCP_BACKUP_EXPIRE_TYPE}" = "days" ]; then
-      find "${BACKUP_ROOTPATH}" -mindepth 1 -maxdepth 1  -type d -mtime "+${OCP_BACKUP_KEEP_DAYS}" -exec rm -rv {} +
-    elif [ "${OCP_BACKUP_EXPIRE_TYPE}" = "count" ]; then
-      # shellcheck disable=SC3040,SC2012
-      ls -1tp "${BACKUP_ROOTPATH}" | awk "NR>${OCP_BACKUP_KEEP_COUNT}" | xargs -I{} rm -rv "${BACKUP_ROOTPATH}/{}"
-    fi
+	# expire backup
+	if [ "${OCP_BACKUP_EXPIRE_TYPE}" = "days" ]; then
+		find "${BACKUP_ROOTPATH}" -mindepth 1 -maxdepth 1 -type d -mtime "+${OCP_BACKUP_KEEP_DAYS}" -exec rm -rv {} +
+	elif [ "${OCP_BACKUP_EXPIRE_TYPE}" = "count" ]; then
+		# shellcheck disable=SC3040,SC2012
+		ls -1tp "${BACKUP_ROOTPATH}" | awk "NR>${OCP_BACKUP_KEEP_COUNT}" | xargs -I{} rm -rv "${BACKUP_ROOTPATH}/{}"
+	fi
 fi


### PR DESCRIPTION
Partially fixes #83

Sets new `OCP_BACKUP_KUBERESOURCSES_S3_*` variables, to push kuberesources which may contain the encrypted keys for the etcd backup (if encryption is enabled on etcd) to a separate bucket.

Only works when using S3, not yet when only using local backup folder.

See https://docs.openshift.com/container-platform/4.12/backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.html

> If etcd encryption is enabled, it is recommended to store this second file separately from the etcd snapshot for security reasons. However, this file is required to restore from the etcd snapshot.
