### PR TITLE
chore(dependabot): change commit message prefix for docker update to fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "feat: "
+      prefix: "fix: "
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Because I accidentally pushed a feature release today I thought it might be a good idea to change the default prefix from `feat` to `fix`, because most of the package updates in the base image are not really relevant for us.