### PR TITLE
feat(): set s3 expiration policies

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -41,7 +41,7 @@ if [ "${OCP_BACKUP_S3}" = "true" ]; then
         *) echo "backup.expiretype needs to be one of: days,never"; exit 1 ;;
     esac
 
-        # validate expire numbers
+    # validate expire numbers
     if [ "${OCP_BACKUP_EXPIRE_TYPE}" = "days" ]; then
         case "${OCP_BACKUP_KEEP_DAYS}" in
             ''|*[!0-9]*) echo "backup.expiredays needs to be a valid number"; exit 1 ;;

--- a/backup.sh
+++ b/backup.sh
@@ -71,29 +71,29 @@ if [ "${OCP_BACKUP_S3}" = "true" ]; then
     rm -rv /host/var/tmp/etcd-backup
 
     # expire backup
-    rules_list=$(mc ilm rule list local/etcd-bucket --json)
-    is_empty=$(echo $rules_list | jq -r 'if .status == "error" then "true" else "false" end')
+    rules_list=$(mc ilm rule list "${OCP_BACKUP_S3_NAME}"/"${OCP_BACKUP_S3_BUCKET}" --json)
+    is_empty=$(echo $rules_list | jq -r "if .status == \"error\" then \"true\" else \"false\" end")
 
     if [ "${OCP_BACKUP_EXPIRE_TYPE}" = "never" ] && [ "$is_empty" = "false" ]; then
-        for rule_id in $(echo $rules_list | jq -r '.config.Rules[].ID'); do
-            echo "OCP_BACKUP_EXPIRE_TYPE is set to 'never'. Deleting rule with ID ${rule_id}..."
-            mc ilm rule rm --id $rule_id local/etcd-bucket
+        for rule_id in $(echo $rules_list | jq -r ".config.Rules[].ID"); do
+            echo "OCP_BACKUP_EXPIRE_TYPE is set to "never". Deleting rule with ID ${rule_id}..."
+            mc ilm rule rm --id $rule_id "${OCP_BACKUP_S3_NAME}"/"${OCP_BACKUP_S3_BUCKET}"
         done
     fi
 
     if [ "${OCP_BACKUP_EXPIRE_TYPE}" = "days" ] && [ "$is_empty" = "false" ]; then
-        for rule_id in $(echo $rules_list | jq -r '.config.Rules[] | select(.Expiration) | .ID'); do
+        for rule_id in $(echo $rules_list | jq -r ".config.Rules[] | select(.Expiration) | .ID"); do
             days=$(echo $rules_list | jq -r ".config.Rules[] | select(.ID == \"$rule_id\") | .Expiration.Days")
             if [ "$days" -ne "$OCP_BACKUP_KEEP_DAYS" ]; then
                 echo "Rule id ${rule_id} does not match the OCP_BACKUP_KEEP_DAYS of ${OCP_BACKUP_KEEP_DAYS} days. Editing the rule..."
-                mc ilm rule edit --id $rule_id --expire-days $OCP_BACKUP_KEEP_DAYS local/etcd-bucket
+                mc ilm rule edit --id $rule_id --expire-days $OCP_BACKUP_KEEP_DAYS "${OCP_BACKUP_S3_NAME}"/"${OCP_BACKUP_S3_BUCKET}"
             fi
         done
     fi
 
     if [ "${OCP_BACKUP_EXPIRE_TYPE}" = "days" ] && [ "$is_empty" = "true" ]; then
         echo "Adding new rule to keep backup for ${OCP_BACKUP_KEEP_DAYS} days"
-        mc ilm rule add --expire-days $OCP_BACKUP_KEEP_DAYS local/etcd-bucket
+        mc ilm rule add --expire-days $OCP_BACKUP_KEEP_DAYS "${OCP_BACKUP_S3_NAME}"/"${OCP_BACKUP_S3_BUCKET}"
     fi
 else
     # prepare, run and copy backup

--- a/backup.sh
+++ b/backup.sh
@@ -72,28 +72,28 @@ if [ "${OCP_BACKUP_S3}" = "true" ]; then
 
     # expire backup
     rules_list=$(mc ilm rule list "${OCP_BACKUP_S3_NAME}"/"${OCP_BACKUP_S3_BUCKET}" --json)
-    is_empty=$(echo $rules_list | jq -r "if .status == \"error\" then \"true\" else \"false\" end")
+    is_empty=$(echo "${rules_list}" | jq -r "if .status == \"error\" then \"true\" else \"false\" end")
 
     if [ "${OCP_BACKUP_EXPIRE_TYPE}" = "never" ] && [ "$is_empty" = "false" ]; then
-        for rule_id in $(echo $rules_list | jq -r ".config.Rules[].ID"); do
+        for rule_id in $(echo "${rules_list}" | jq -r ".config.Rules[].ID"); do
             echo "OCP_BACKUP_EXPIRE_TYPE is set to "never". Deleting rule with ID ${rule_id}..."
-            mc ilm rule rm --id $rule_id "${OCP_BACKUP_S3_NAME}"/"${OCP_BACKUP_S3_BUCKET}"
+            mc ilm rule rm --id "${rule_id}" "${OCP_BACKUP_S3_NAME}"/"${OCP_BACKUP_S3_BUCKET}"
         done
     fi
 
-    if [ "${OCP_BACKUP_EXPIRE_TYPE}" = "days" ] && [ "$is_empty" = "false" ]; then
-        for rule_id in $(echo $rules_list | jq -r ".config.Rules[] | select(.Expiration) | .ID"); do
-            days=$(echo $rules_list | jq -r ".config.Rules[] | select(.ID == \"$rule_id\") | .Expiration.Days")
+    if [ "${OCP_BACKUP_EXPIRE_TYPE}" = "days" ] && [ "${is_empty}" = "false" ]; then
+        for rule_id in $(echo "${rules_list}" | jq -r ".config.Rules[] | select(.Expiration) | .ID"); do
+            days=$(echo "${rules_list}" | jq -r ".config.Rules[] | select(.ID == \"${rule_id}\") | .Expiration.Days")
             if [ "$days" -ne "$OCP_BACKUP_KEEP_DAYS" ]; then
                 echo "Rule id ${rule_id} does not match the OCP_BACKUP_KEEP_DAYS of ${OCP_BACKUP_KEEP_DAYS} days. Editing the rule..."
-                mc ilm rule edit --id $rule_id --expire-days $OCP_BACKUP_KEEP_DAYS "${OCP_BACKUP_S3_NAME}"/"${OCP_BACKUP_S3_BUCKET}"
+                mc ilm rule edit --id $rule_id --expire-days "${OCP_BACKUP_KEEP_DAYS}" "${OCP_BACKUP_S3_NAME}"/"${OCP_BACKUP_S3_BUCKET}"
             fi
         done
     fi
 
     if [ "${OCP_BACKUP_EXPIRE_TYPE}" = "days" ] && [ "$is_empty" = "true" ]; then
         echo "Adding new rule to keep backup for ${OCP_BACKUP_KEEP_DAYS} days"
-        mc ilm rule add --expire-days $OCP_BACKUP_KEEP_DAYS "${OCP_BACKUP_S3_NAME}"/"${OCP_BACKUP_S3_BUCKET}"
+        mc ilm rule add --expire-days "${OCP_BACKUP_KEEP_DAYS}" "${OCP_BACKUP_S3_NAME}"/"${OCP_BACKUP_S3_BUCKET}"
     fi
 else
     # prepare, run and copy backup

--- a/backup.sh
+++ b/backup.sh
@@ -76,7 +76,7 @@ if [ "${OCP_BACKUP_S3}" = "true" ]; then
 
     if [ "${OCP_BACKUP_EXPIRE_TYPE}" = "never" ] && [ "$is_empty" = "false" ]; then
         for rule_id in $(echo "${rules_list}" | jq -r ".config.Rules[].ID"); do
-            echo "OCP_BACKUP_EXPIRE_TYPE is set to "never". Deleting rule with ID ${rule_id}..."
+            echo "OCP_BACKUP_EXPIRE_TYPE is set to \"never\". Deleting rule with ID ${rule_id}..."
             mc ilm rule rm --id "${rule_id}" "${OCP_BACKUP_S3_NAME}"/"${OCP_BACKUP_S3_BUCKET}"
         done
     fi
@@ -86,7 +86,7 @@ if [ "${OCP_BACKUP_S3}" = "true" ]; then
             days=$(echo "${rules_list}" | jq -r ".config.Rules[] | select(.ID == \"${rule_id}\") | .Expiration.Days")
             if [ "$days" -ne "$OCP_BACKUP_KEEP_DAYS" ]; then
                 echo "Rule id ${rule_id} does not match the OCP_BACKUP_KEEP_DAYS of ${OCP_BACKUP_KEEP_DAYS} days. Editing the rule..."
-                mc ilm rule edit --id $rule_id --expire-days "${OCP_BACKUP_KEEP_DAYS}" "${OCP_BACKUP_S3_NAME}"/"${OCP_BACKUP_S3_BUCKET}"
+                mc ilm rule edit --id "${rule_id}" --expire-days "${OCP_BACKUP_KEEP_DAYS}" "${OCP_BACKUP_S3_NAME}"/"${OCP_BACKUP_S3_BUCKET}"
             fi
         done
     fi

--- a/backup.sh
+++ b/backup.sh
@@ -71,7 +71,7 @@ if [ "${OCP_BACKUP_S3}" = "true" ]; then
     rm -rv /host/var/tmp/etcd-backup
 
     # expire backup
-    rules_list=$(mc ilm rule list local/etcd-bucket --json | jq -c '.')
+    rules_list=$(mc ilm rule list local/etcd-bucket --json)
     is_empty=$(echo $rules_list | jq -r 'if .status == "error" then "true" else "false" end')
 
     if [ "${OCP_BACKUP_EXPIRE_TYPE}" = "never" ] && [ "$is_empty" = "false" ]; then


### PR DESCRIPTION
Add support for setting `OCP_BACKUP_EXPIRE_TYPE` and `OCP_BACKUP_KEEP_DAYS` for backups using s3 compatible backend.

To avoid adding the same rule multiple times, the script checks whether such rule already exists. In case of `OCP_BACKUP_EXPIRE_TYPE=never`, all rules are deleted.