### PR TITLE
fix: backup.sh commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.vendor="Adfinis"
 COPY backup.sh /usr/local/bin/backup.sh
 
 RUN microdnf update -y && rm -rf /var/cache/yum
-RUN microdnf install findutils -y && microdnf clean all
+RUN microdnf install findutils jq -y && microdnf clean all
 RUN curl -O https://dl.min.io/client/mc/release/linux-amd64/mc.rpm \
  && rpm -ih mc.rpm \
  && rm mc.rpm


### PR DESCRIPTION
Fixed items:

- wrong mcli usage in a few places
- script unexpectedly ends when no lifecycle rule is found for the given s3 bucket
- missing jq binary in container