### PR TITLE
fix(ci): replace GITHUB_TOKEN with PAT

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -21,5 +21,5 @@ jobs:
         id: semrel
         uses: go-semantic-release/action@v1.24
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PAT }}
           allow-initial-development-versions: true


### PR DESCRIPTION
to allow triggering of release container image pipeline

* fixes #105 